### PR TITLE
Removed double init

### DIFF
--- a/algo/axiom.c
+++ b/algo/axiom.c
@@ -17,7 +17,7 @@ void axiomhash(void *output, const void *input)
 	sph_shabal256_close(&ctx, M[0]);
 
 	for(int i = 1; i < N; i++) {
-		//sph_shabal256_init(&ctx);
+		sph_shabal256_init(&ctx);
 		sph_shabal256(&ctx, M[i-1], 32);
 		sph_shabal256_close(&ctx, M[i]);
 	}
@@ -28,7 +28,7 @@ void axiomhash(void *output, const void *input)
 		const int q = M[p][0] % 0xFFFF;
 		const int j = (b + q) % N;
 
-		//sph_shabal256_init(&ctx);
+		sph_shabal256_init(&ctx);
 #if 0
 		sph_shabal256(&ctx, M[p], 32);
 		sph_shabal256(&ctx, M[j], 32);

--- a/algo/groestl.c
+++ b/algo/groestl.c
@@ -20,7 +20,7 @@ void groestlhash(void *output, const void *input)
 	sph_groestl512(&ctx, input, 80);
 	sph_groestl512_close(&ctx, hash);
 
-	//sph_groestl512_init(&ctx);
+	sph_groestl512_init(&ctx);
 	sph_groestl512(&ctx, hash, 64);
 	sph_groestl512_close(&ctx, hash);
 

--- a/algo/lbry.c
+++ b/algo/lbry.c
@@ -41,24 +41,32 @@ void lbry_hash(void* output, const void* input)
 	// sha256d
 	sph_sha256(&ctx.sha256, input, 112);
 	sph_sha256_close(&ctx.sha256, hashA);
+    sph_sha256_init(&ctx.sha256);
+
 	sph_sha256(&ctx.sha256, hashA, 32);
 	sph_sha256_close(&ctx.sha256, hashA);
+    sph_sha256_init(&ctx.sha256);
 
 	sph_sha512(&ctx.sha512, hashA, 32);
 	sph_sha512_close(&ctx.sha512, hashA);
+    sph_sha512_init(&ctx.sha512);
 
 	sph_ripemd160(&ctx.ripemd, hashA, 32);
 	sph_ripemd160_close(&ctx.ripemd, hashB);
+    sph_ripemd160_init(&ctx.ripemd);
 
 	sph_ripemd160(&ctx.ripemd, &hashA[8], 32); // weird
 	sph_ripemd160_close(&ctx.ripemd, hashC);
+    sph_ripemd160_init(&ctx.ripemd);
 
 	sph_sha256(&ctx.sha256, hashB, 20);
 	sph_sha256(&ctx.sha256, hashC, 20);
 	sph_sha256_close(&ctx.sha256, hashA);
+    sph_sha256_init(&ctx.sha256);
 
 	sph_sha256(&ctx.sha256, hashA, 32);
 	sph_sha256_close(&ctx.sha256, hashA);
+    sph_sha256_init(&ctx.sha256);
 
 	memcpy(output, hashA, 32);
 }

--- a/algo/pentablake.c
+++ b/algo/pentablake.c
@@ -21,15 +21,19 @@ extern void pentablakehash(void *output, const void *input)
 	sph_blake512(&ctx_blake, input, 80);
 	sph_blake512_close(&ctx_blake, hash);
 
+    sph_blake512_init(&ctx_blake);
 	sph_blake512(&ctx_blake, hash, 64);
 	sph_blake512_close(&ctx_blake, hashB);
 
+    sph_blake512_init(&ctx_blake);
 	sph_blake512(&ctx_blake, hashB, 64);
 	sph_blake512_close(&ctx_blake, hash);
 
+    sph_blake512_init(&ctx_blake);
 	sph_blake512(&ctx_blake, hash, 64);
 	sph_blake512_close(&ctx_blake, hashB);
 
+    sph_blake512_init(&ctx_blake);
 	sph_blake512(&ctx_blake, hashB, 64);
 	sph_blake512_close(&ctx_blake, hash);
 

--- a/sha3/sph_blake.c
+++ b/sha3/sph_blake.c
@@ -1028,7 +1028,6 @@ void
 sph_blake224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	blake32_close(cc, ub, n, dst, 7);
-	sph_blake224_init(cc);
 }
 
 /* see sph_blake.h */
@@ -1057,7 +1056,6 @@ void
 sph_blake256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	blake32_close(cc, ub, n, dst, 8);
-	sph_blake256_init(cc);
 }
 
 #if SPH_64
@@ -1088,7 +1086,6 @@ void
 sph_blake384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	blake64_close(cc, ub, n, dst, 6);
-	sph_blake384_init(cc);
 }
 
 /* see sph_blake.h */
@@ -1117,7 +1114,6 @@ void
 sph_blake512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	blake64_close(cc, ub, n, dst, 8);
-	sph_blake512_init(cc);
 }
 
 #endif

--- a/sha3/sph_bmw.c
+++ b/sha3/sph_bmw.c
@@ -866,7 +866,6 @@ void
 sph_bmw224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	bmw32_close(cc, ub, n, dst, 7);
-	sph_bmw224_init(cc);
 }
 
 /* see sph_bmw.h */
@@ -895,7 +894,6 @@ void
 sph_bmw256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	bmw32_close(cc, ub, n, dst, 8);
-	sph_bmw256_init(cc);
 }
 
 #if SPH_64
@@ -926,7 +924,6 @@ void
 sph_bmw384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	bmw64_close(cc, ub, n, dst, 6);
-	sph_bmw384_init(cc);
 }
 
 /* see sph_bmw.h */
@@ -955,7 +952,6 @@ void
 sph_bmw512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	bmw64_close(cc, ub, n, dst, 8);
-	sph_bmw512_init(cc);
 }
 
 #endif

--- a/sha3/sph_cubehash.c
+++ b/sha3/sph_cubehash.c
@@ -629,7 +629,6 @@ void
 sph_cubehash224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	cubehash_close(cc, ub, n, dst, 7);
-	sph_cubehash224_init(cc);
 }
 
 /* see sph_cubehash.h */
@@ -658,7 +657,6 @@ void
 sph_cubehash256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	cubehash_close(cc, ub, n, dst, 8);
-	sph_cubehash256_init(cc);
 }
 
 /* see sph_cubehash.h */
@@ -687,7 +685,6 @@ void
 sph_cubehash384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	cubehash_close(cc, ub, n, dst, 12);
-	sph_cubehash384_init(cc);
 }
 
 /* see sph_cubehash.h */
@@ -716,7 +713,6 @@ void
 sph_cubehash512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	cubehash_close(cc, ub, n, dst, 16);
-	sph_cubehash512_init(cc);
 }
 #ifdef __cplusplus
 }

--- a/sha3/sph_echo.c
+++ b/sha3/sph_echo.c
@@ -853,7 +853,6 @@ echo_small_close(sph_echo_small_context *sc, unsigned ub, unsigned n,
 		sph_enc32le_aligned(u.tmp + (k << 2), VV[k]);
 #endif
 	memcpy(dst, u.tmp, out_size_w32 << 2);
-	echo_small_init(sc, out_size_w32 << 5);
 }
 
 static void
@@ -912,7 +911,6 @@ echo_big_close(sph_echo_big_context *sc, unsigned ub, unsigned n,
 		sph_enc32le_aligned(u.tmp + (k << 2), VV[k]);
 #endif
 	memcpy(dst, u.tmp, out_size_w32 << 2);
-	echo_big_init(sc, out_size_w32 << 5);
 }
 
 /* see sph_echo.h */

--- a/sha3/sph_fugue.c
+++ b/sha3/sph_fugue.c
@@ -994,9 +994,6 @@ fugue2_close(sph_fugue_context *sc, unsigned ub, unsigned n,
 	sph_enc32be(out + 24, S[17]);
 	if (out_size_w32 == 8) {
 		sph_enc32be(out + 28, S[18]);
-		sph_fugue256_init(sc);
-	} else {
-		sph_fugue224_init(sc);
 	}
 }
 
@@ -1044,7 +1041,6 @@ fugue3_close(sph_fugue_context *sc, unsigned ub, unsigned n, void *dst)
 	sph_enc32be(out + 36, S[25]);
 	sph_enc32be(out + 40, S[26]);
 	sph_enc32be(out + 44, S[27]);
-	sph_fugue384_init(sc);
 }
 
 static void
@@ -1105,7 +1101,6 @@ fugue4_close(sph_fugue_context *sc, unsigned ub, unsigned n, void *dst)
 	sph_enc32be(out + 52, S[28]);
 	sph_enc32be(out + 56, S[29]);
 	sph_enc32be(out + 60, S[30]);
-	sph_fugue512_init(sc);
 }
 
 void

--- a/sha3/sph_groestl.c
+++ b/sha3/sph_groestl.c
@@ -2865,7 +2865,6 @@ groestl_small_close(sph_groestl_small_context *sc,
 		enc32e(pad + (u << 2), H[u + 8]);
 #endif
 	memcpy(dst, pad + 32 - out_len, out_len);
-	groestl_small_init(sc, (unsigned)out_len << 3);
 }
 
 static void
@@ -2999,7 +2998,6 @@ groestl_big_close(sph_groestl_big_context *sc,
 		enc32e(pad + (u << 2), H[u + 16]);
 #endif
 	memcpy(dst, pad + 64 - out_len, out_len);
-	groestl_big_init(sc, (unsigned)out_len << 3);
 }
 
 /* see sph_groestl.h */

--- a/sha3/sph_hamsi.c
+++ b/sha3/sph_hamsi.c
@@ -761,7 +761,6 @@ void
 sph_hamsi224_close(void *cc, void *dst)
 {
 	hamsi_small_close(cc, 0, 0, dst, 7);
-	hamsi_small_init(cc, IV224);
 }
 
 /* see sph_hamsi.h */
@@ -769,7 +768,6 @@ void
 sph_hamsi224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	hamsi_small_close(cc, ub, n, dst, 7);
-	hamsi_small_init(cc, IV224);
 }
 
 /* see sph_hamsi.h */
@@ -791,7 +789,6 @@ void
 sph_hamsi256_close(void *cc, void *dst)
 {
 	hamsi_small_close(cc, 0, 0, dst, 8);
-	hamsi_small_init(cc, IV256);
 }
 
 /* see sph_hamsi.h */
@@ -799,7 +796,6 @@ void
 sph_hamsi256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	hamsi_small_close(cc, ub, n, dst, 8);
-	hamsi_small_init(cc, IV256);
 }
 
 /* see sph_hamsi.h */
@@ -821,7 +817,6 @@ void
 sph_hamsi384_close(void *cc, void *dst)
 {
 	hamsi_big_close(cc, 0, 0, dst, 12);
-	hamsi_big_init(cc, IV384);
 }
 
 /* see sph_hamsi.h */
@@ -829,7 +824,6 @@ void
 sph_hamsi384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	hamsi_big_close(cc, ub, n, dst, 12);
-	hamsi_big_init(cc, IV384);
 }
 
 /* see sph_hamsi.h */
@@ -851,7 +845,6 @@ void
 sph_hamsi512_close(void *cc, void *dst)
 {
 	hamsi_big_close(cc, 0, 0, dst, 16);
-	hamsi_big_init(cc, IV512);
 }
 
 /* see sph_hamsi.h */
@@ -859,7 +852,6 @@ void
 sph_hamsi512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	hamsi_big_close(cc, ub, n, dst, 16);
-	hamsi_big_init(cc, IV512);
 }
 
 #ifdef __cplusplus

--- a/sha3/sph_jh.c
+++ b/sha3/sph_jh.c
@@ -996,7 +996,6 @@ jh_close(sph_jh_context *sc, unsigned ub, unsigned n,
 		enc32e(buf + (u << 2), sc->H.narrow[u + 16]);
 #endif
 	memcpy(dst, buf + ((16 - out_size_w32) << 2), out_size_w32 << 2);
-	jh_init(sc, iv);
 }
 
 /* see sph_jh.h */

--- a/sha3/sph_keccak.c
+++ b/sha3/sph_keccak.c
@@ -1643,7 +1643,6 @@ keccak_core(sph_keccak_context *kc, const void *data, size_t len, size_t lim)
 		for (j = 0; j < d; j += 8) \
 			sph_enc64le_aligned(u.tmp + j, kc->u.wide[j >> 3]); \
 		memcpy(dst, u.tmp, d); \
-		keccak_init(kc, (unsigned)d << 3); \
 	} \
 
 #else
@@ -1696,7 +1695,6 @@ keccak_core(sph_keccak_context *kc, const void *data, size_t len, size_t lim)
 		for (j = 0; j < d; j += 4) \
 			sph_enc32le_aligned(u.tmp + j, kc->u.narrow[j >> 2]); \
 		memcpy(dst, u.tmp, d); \
-		keccak_init(kc, (unsigned)d << 3); \
 	} \
 
 #endif

--- a/sha3/sph_luffa.c
+++ b/sha3/sph_luffa.c
@@ -1319,7 +1319,6 @@ void
 sph_luffa224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	luffa3_close(cc, ub, n, dst, 7);
-	sph_luffa224_init(cc);
 }
 
 /* see sph_luffa.h */
@@ -1352,7 +1351,6 @@ void
 sph_luffa256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	luffa3_close(cc, ub, n, dst, 8);
-	sph_luffa256_init(cc);
 }
 
 /* see sph_luffa.h */
@@ -1385,7 +1383,6 @@ void
 sph_luffa384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	luffa4_close(cc, ub, n, dst);
-	sph_luffa384_init(cc);
 }
 
 /* see sph_luffa.h */
@@ -1418,7 +1415,6 @@ void
 sph_luffa512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	luffa5_close(cc, ub, n, dst);
-	sph_luffa512_init(cc);
 }
 
 #ifdef __cplusplus

--- a/sha3/sph_ripemd.c
+++ b/sha3/sph_ripemd.c
@@ -273,7 +273,6 @@ void
 sph_ripemd_close(void *cc, void *dst)
 {
 	ripemd_close(cc, dst, 4);
-	sph_ripemd_init(cc);
 }
 
 /* see sph_ripemd.h */
@@ -527,7 +526,6 @@ void
 sph_ripemd128_close(void *cc, void *dst)
 {
 	ripemd128_close(cc, dst, 4);
-	sph_ripemd128_init(cc);
 }
 
 /* see sph_ripemd.h */
@@ -820,7 +818,6 @@ void
 sph_ripemd160_close(void *cc, void *dst)
 {
 	ripemd160_close(cc, dst, 5);
-	sph_ripemd160_init(cc);
 }
 
 /* see sph_ripemd.h */

--- a/sha3/sph_sha2.c
+++ b/sha3/sph_sha2.c
@@ -653,7 +653,6 @@ void
 sph_sha224_close(void *cc, void *dst)
 {
 	sha224_close(cc, dst, 7);
-	sph_sha224_init(cc);
 }
 
 /* see sph_sha2.h */
@@ -661,7 +660,6 @@ void
 sph_sha224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	sha224_addbits_and_close(cc, ub, n, dst, 7);
-	sph_sha224_init(cc);
 }
 
 /* see sph_sha2.h */
@@ -669,7 +667,6 @@ void
 sph_sha256_close(void *cc, void *dst)
 {
 	sha224_close(cc, dst, 8);
-	sph_sha256_init(cc);
 }
 
 /* see sph_sha2.h */
@@ -677,7 +674,6 @@ void
 sph_sha256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	sha224_addbits_and_close(cc, ub, n, dst, 8);
-	sph_sha256_init(cc);
 }
 
 /* see sph_sha2.h */

--- a/sha3/sph_sha2big.c
+++ b/sha3/sph_sha2big.c
@@ -208,7 +208,6 @@ void
 sph_sha384_close(void *cc, void *dst)
 {
 	sha384_close(cc, dst, 6);
-	sph_sha384_init(cc);
 }
 
 /* see sph_sha3.h */
@@ -216,7 +215,6 @@ void
 sph_sha384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	sha384_addbits_and_close(cc, ub, n, dst, 6);
-	sph_sha384_init(cc);
 }
 
 /* see sph_sha3.h */
@@ -224,7 +222,6 @@ void
 sph_sha512_close(void *cc, void *dst)
 {
 	sha384_close(cc, dst, 8);
-	sph_sha512_init(cc);
 }
 
 /* see sph_sha3.h */
@@ -232,7 +229,6 @@ void
 sph_sha512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	sha384_addbits_and_close(cc, ub, n, dst, 8);
-	sph_sha512_init(cc);
 }
 
 /* see sph_sha3.h */

--- a/sha3/sph_shabal.c
+++ b/sha3/sph_shabal.c
@@ -658,7 +658,6 @@ shabal_close(void *cc, unsigned ub, unsigned n, void *dst, unsigned size_words)
 	}
 	out_len = size_words << 2;
 	memcpy(dst, u.tmp_out + (sizeof u.tmp_out) - out_len, out_len);
-	shabal_init(sc, size_words << 5);
 }
 #if 0
 /* see sph_shabal.h */

--- a/sha3/sph_shavite.c
+++ b/sha3/sph_shavite.c
@@ -1658,7 +1658,6 @@ void
 sph_shavite224_close(void *cc, void *dst)
 {
 	shavite_small_close(cc, 0, 0, dst, 7);
-	shavite_small_init(cc, IV224);
 }
 
 /* see sph_shavite.h */
@@ -1666,7 +1665,6 @@ void
 sph_shavite224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shavite_small_close(cc, ub, n, dst, 7);
-	shavite_small_init(cc, IV224);
 }
 
 /* see sph_shavite.h */
@@ -1688,7 +1686,6 @@ void
 sph_shavite256_close(void *cc, void *dst)
 {
 	shavite_small_close(cc, 0, 0, dst, 8);
-	shavite_small_init(cc, IV256);
 }
 
 /* see sph_shavite.h */
@@ -1696,7 +1693,6 @@ void
 sph_shavite256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shavite_small_close(cc, ub, n, dst, 8);
-	shavite_small_init(cc, IV256);
 }
 
 /* see sph_shavite.h */
@@ -1718,7 +1714,6 @@ void
 sph_shavite384_close(void *cc, void *dst)
 {
 	shavite_big_close(cc, 0, 0, dst, 12);
-	shavite_big_init(cc, IV384);
 }
 
 /* see sph_shavite.h */
@@ -1726,7 +1721,6 @@ void
 sph_shavite384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shavite_big_close(cc, ub, n, dst, 12);
-	shavite_big_init(cc, IV384);
 }
 
 /* see sph_shavite.h */
@@ -1748,7 +1742,6 @@ void
 sph_shavite512_close(void *cc, void *dst)
 {
 	shavite_big_close(cc, 0, 0, dst, 16);
-	shavite_big_init(cc, IV512);
 }
 
 /* see sph_shavite.h */
@@ -1756,7 +1749,6 @@ void
 sph_shavite512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shavite_big_close(cc, ub, n, dst, 16);
-	shavite_big_init(cc, IV512);
 }
 
 #ifdef __cplusplus

--- a/sha3/sph_simd.c
+++ b/sha3/sph_simd.c
@@ -1717,7 +1717,6 @@ void
 sph_simd224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	finalize_small(cc, ub, n, dst, 7);
-	sph_simd224_init(cc);
 }
 
 void
@@ -1742,7 +1741,6 @@ void
 sph_simd256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	finalize_small(cc, ub, n, dst, 8);
-	sph_simd256_init(cc);
 }
 
 void
@@ -1767,7 +1765,6 @@ void
 sph_simd384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	finalize_big(cc, ub, n, dst, 12);
-	sph_simd384_init(cc);
 }
 
 void
@@ -1792,7 +1789,6 @@ void
 sph_simd512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	finalize_big(cc, ub, n, dst, 16);
-	sph_simd512_init(cc);
 }
 #ifdef __cplusplus
 }

--- a/sha3/sph_skein.c
+++ b/sha3/sph_skein.c
@@ -1156,7 +1156,6 @@ void
 sph_skein224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	skein_big_close(cc, ub, n, dst, 28);
-	sph_skein224_init(cc);
 }
 
 /* see sph_skein.h */
@@ -1185,7 +1184,6 @@ void
 sph_skein256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	skein_big_close(cc, ub, n, dst, 32);
-	sph_skein256_init(cc);
 }
 
 /* see sph_skein.h */
@@ -1214,7 +1212,6 @@ void
 sph_skein384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	skein_big_close(cc, ub, n, dst, 48);
-	sph_skein384_init(cc);
 }
 
 /* see sph_skein.h */
@@ -1243,7 +1240,6 @@ void
 sph_skein512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	skein_big_close(cc, ub, n, dst, 64);
-	sph_skein512_init(cc);
 }
 
 #endif

--- a/sha3/sph_whirlpool.c
+++ b/sha3/sph_whirlpool.c
@@ -3468,7 +3468,6 @@ sph_ ## name ## _close(void *cc, void *dst) \
 	sc = cc; \
 	for (i = 0; i < 8; i ++) \
 		sph_enc64le((unsigned char *)dst + 8 * i, sc->state[i]); \
-	sph_ ## name ## _init(cc); \
 }
 
 MAKE_CLOSE(whirlpool)


### PR DESCRIPTION
SHA3 - Double init issue

Please have a look at any sph_*_close function:

algo/x11.c

    39    sph_blake512_init(&ctx_blake);
    40    sph_blake512 (&ctx_blake, input, 80);
    41    sph_blake512_close (&ctx_blake, hashA);

    42    sph_bmw512_init(&ctx_bmw);
    43    sph_bmw512 (&ctx_bmw, hashA, 64);
    44    sph_bmw512_close(&ctx_bmw, hashB);

In sha3/sph_blake.c you can see:

    sph_blake512_close(void *cc, void *dst)
    {
        sph_blake512_addbits_and_close(cc, 0, 0, dst);
    }

    void
    sph_blake512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
    {
        blake64_close(cc, ub, n, dst, 8);
        sph_blake512_init(cc);
    }

When we call `sph_blake512_close` context is automaticly initialized by `sph_blake512_init`, but we do not use it in next steps! (especially in X11, X13, X14, X15, x17)

The same situation in other sha3 algos like `echo512`. Init is call after `sph_echo512_close` (`echo_big_close` function`)

I removed all inits when we call `sph_*_close` function.

If you would like to use the same hash function twice, you have to use `sph_*_init(&ctx);` every time!

    sph_groestl512_init(&ctx);         // <======= Init Context
    sph_groestl512(&ctx, input, 80);
    sph_groestl512_close(&ctx, hash);

    sph_groestl512_init(&ctx);         // <======= Init context after close!
    sph_groestl512(&ctx, hash, 64);
    sph_groestl512_close(&ctx, hash);    

instead of (old version)

    sph_groestl512_init(&ctx);        // <======= Init Context
    sph_groestl512(&ctx, input, 80);
    sph_groestl512_close(&ctx, hash); // <======= Init context available in
                                      //          close function has been removed!

    sph_groestl512(&ctx, hash, 64);
    sph_groestl512_close(&ctx, hash);    


Depends on system architecture, this patch can improve hashing speed between 0.05% - 1%