### PR TITLE
Set defaults for curl and openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,7 @@ fi
 
 # libcurl install path (for mingw : --with-curl=/usr/local)
 AC_ARG_WITH([curl],
-   [  --with-curl=PATH         prefix where curl is installed [default=/usr]])
+   [  --with-curl=PATH         prefix where curl is installed [default=/usr]],,with_curl=/usr)
 
 if test -n "$with_curl" ; then
    LIBCURL_CFLAGS="$LIBCURL_CFLAGS -I$with_curl/include"
@@ -152,7 +152,7 @@ fi
 
 # SSL install path (for mingw : --with-crypto=/usr/local/ssl)
 AC_ARG_WITH([crypto],
-   [  --with-crypto=PATH       prefix where openssl crypto is installed [default=/usr]])
+   [  --with-crypto=PATH       prefix where openssl crypto is installed [default=/usr]],,with_crypto=/usr)
 
 if test -n "$with_crypto" ; then
    LIBCURL_CFLAGS="$LIBCURL_CFLAGS -I$with_crypto/include"


### PR DESCRIPTION
otherwise the link fails since with_crpto and with_curl are empty
and so the libs are missing on the linker command line:

    g++  -g -O2   -o cpuminer cpuminer-cpu-miner.o cpuminer-util.o cpuminer-api.o cpuminer-sysinfos.o cpuminer-uint256.o sha3/cpuminer-sph_keccak.o sha3/cpuminer-sph_hefty1.o sha3/cpuminer-sph_groestl.o sha3/cpuminer-sph_skein.o sha3/cpuminer-sph_bmw.o sha3/cpuminer-sph_jh.o sha3/cpuminer-sph_shavite.o sha3/cpuminer-sph_blake.o sha3/cpuminer-mod_blakecoin.o sha3/cpuminer-sph_luffa.o sha3/cpuminer-sph_cubehash.o sha3/cpuminer-sph_simd.o sha3/cpuminer-sph_echo.o sha3/cpuminer-sph_hamsi.o sha3/cpuminer-sph_haval.o sha3/cpuminer-sph_fugue.o sha3/cpuminer-sph_ripemd.o sha3/cpuminer-sph_sha2.o sha3/cpuminer-sph_sha2big.o sha3/cpuminer-sph_shabal.o sha3/cpuminer-sph_whirlpool.o sha3/cpuminer-gost_streebog.o crypto/cpuminer-blake2s.o crypto/cpuminer-blake2b.o crypto/cpuminer-oaes_lib.o crypto/cpuminer-c_keccak.o crypto/cpuminer-c_groestl.o crypto/cpuminer-c_blake256.o crypto/cpuminer-c_jh.o crypto/cpuminer-c_skein.o crypto/cpuminer-hash.o crypto/cpuminer-aesb.o lyra2/cpuminer-Lyra2.o lyra2/cpuminer-Sponge.o yescrypt/cpuminer-yescrypt-common.o yescrypt/cpuminer-yescrypt-best.o yescrypt/cpuminer-sha256_Y.o algo/cpuminer-axiom.o algo/cpuminer-bastion.o algo/cpuminer-blake.o algo/cpuminer-blakecoin.o algo/cpuminer-blake2.o algo/cpuminer-bmw256.o algo/cpuminer-c11.o algo/cpuminer-cryptonight.o algo/cpuminer-cryptolight.o algo/cpuminer-decred.o algo/cpuminer-drop.o algo/cpuminer-fresh.o algo/cpuminer-groestl.o algo/cpuminer-heavy.o algo/cpuminer-ink.o algo/cpuminer-lbry.o algo/cpuminer-luffa.o algo/cpuminer-lyra2re.o algo/cpuminer-lyra2rev2.o algo/cpuminer-myr-groestl.o algo/cpuminer-keccak.o algo/cpuminer-pentablake.o algo/cpuminer-quark.o algo/cpuminer-neoscrypt.o algo/cpuminer-nist5.o algo/cpuminer-pluck.o algo/cpuminer-qubit.o algo/cpuminer-scrypt.o algo/cpuminer-scrypt-jane.o algo/cpuminer-sha2.o algo/cpuminer-sia.o algo/cpuminer-sibcoin.o algo/cpuminer-skein.o algo/cpuminer-skein2.o algo/cpuminer-s3.o algo/cpuminer-timetravel.o algo/cpuminer-veltor.o algo/cpuminer-x11evo.o algo/cpuminer-x11.o algo/cpuminer-x13.o algo/cpuminer-x14.o algo/cpuminer-x15.o algo/cpuminer-x17.o algo/cpuminer-xevan.o algo/cpuminer-yescrypt.o algo/cpuminer-zr5.o asm/cpuminer-neoscrypt_asm.o  asm/cpuminer-sha2-x64.o asm/cpuminer-scrypt-x64.o asm/cpuminer-aesb-x64.o   compat/jansson/libjansson.a -lpthread
    cpuminer-cpu-miner.o: In function `longpoll_thread':
    /var/scratch/debian/cpuminer-multi/cpu-miner.c:2407: undefined reference to `curl_easy_init'
    /var/scratch/debian/cpuminer-multi/cpu-miner.c:2532: undefined reference to `curl_easy_cleanup'
    cpuminer-cpu-miner.o: In function `stratum_gen_work':
    /var/scratch/debian/cpuminer-multi/cpu-miner.c:1684: undefined reference to `SHA256'
    cpuminer-cpu-miner.o: In function `workio_thread':
    /var/scratch/debian/cpuminer-multi/cpu-miner.c:1533: undefined reference to `curl_easy_init'
    /var/scratch/debian/cpuminer-multi/cpu-miner.c:1571: undefined reference to `curl_easy_cleanup'
    …