### PR TITLE
Fix compilation on pi64

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ _OR_
  apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++
 ```
 
+#### Note for Pi64 users:
+
+```
+ ./configure --disable-assembly CFLAGS="-Ofast -march=native" --with-crypto --with-curl
+```
+
 #### Notes for AIX users:
  * To build a 64-bit binary, export OBJECT_MODE=64
  * GNU-style long options are not supported, but are accessible via configuration file

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ _OR_
  apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++
 ```
 
-#### Note for Pi64 users:
+#### Note for pi64 users:
 
 ```
  ./configure --disable-assembly CFLAGS="-Ofast -march=native" --with-crypto --with-curl

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,9 @@ case $MINGW_TARGET in
   arm*-*-*)
     have_arm=true
     ;;
+  aarch64*-*-*)
+    have_arm=true
+    ;;
   i*86-*-mingw*)
     have_x86=true
     have_win32=true

--- a/sysinfos.c
+++ b/sysinfos.c
@@ -111,7 +111,7 @@ int cpu_fanpercent()
 	return 0;
 }
 
-#ifndef __arm__
+#if !defined(__arm__) || !defined(__aarch64__)
 static inline void cpuid(int functionnumber, int output[4]) {
 #if defined (_MSC_VER) || defined (__INTEL_COMPILER)
 	// Microsoft or Intel compiler, intrin.h included
@@ -245,7 +245,7 @@ void cpu_getmodelid(char *outbuf, size_t maxsz)
 
 bool has_aes_ni()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 	return false;
 #else
 	int cpu_info[4] = { 0 };
@@ -256,7 +256,7 @@ bool has_aes_ni()
 
 void cpu_bestfeature(char *outbuf, size_t maxsz)
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 	sprintf(outbuf, "ARM");
 #else
 	int cpu_info[4] = { 0 };


### PR DESCRIPTION
These changes fix compilation errors on RPi 3 with pi64 and possibly other aarch64 devices that have a 64 bit OS