### PR TITLE
Unhardcode bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$OS" = "Windows_NT" ]; then
     ./mingw64.sh


### PR DESCRIPTION
There are linux distros which do not keep bash at `/bin/bash`