### PR TITLE
adding zlib1g-dev to the note for debian users

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ _OR_
 #### Note for Debian/Ubuntu users:
 
 ```
- apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++
+ apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++ zlib1g-dev
 ```
 
 #### Note for pi64 users:


### PR DESCRIPTION
In the readme, zlib's dev package should be added to the apt-get instructions.