### PR TITLE
Add flodata option for FLO Blockchain coinbase message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ sign/
 sign.sh
 
 compat/curl-for-windows/
+*.swp

--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -872,7 +872,7 @@ static bool gbt_work_decode(const json_t *val, struct work *work)
 		}
 		cbvalue = (int64_t) (json_is_integer(tmp) ? json_integer_value(tmp) : json_number_value(tmp));
 		cbtx = (uchar*) malloc(256);
-		le32enc((uint32_t *)cbtx, 1); /* version */
+		le32enc((uint32_t *)cbtx, 2); /* version */
 		cbtx[4] = 1; /* in-counter */
 		memset(cbtx+5, 0x00, 32); /* prev txout hash */
 		le32enc((uint32_t *)(cbtx+37), 0xffffffff); /* prev txout index */
@@ -898,6 +898,11 @@ static bool gbt_work_decode(const json_t *val, struct work *work)
 		cbtx_size += (int) pk_script_size;
 		le32enc((uint32_t *)(cbtx+cbtx_size), 0); /* lock time */
 		cbtx_size += 4;
+		const char* floData = "MLG cpuminer-multi";
+		char floDataLen = strlen(floData); // only works if floData is less than 252 chars
+		cbtx[cbtx_size++] = floDataLen;    // else the encoded varInt will be wrong
+		memcpy(cbtx+cbtx_size, floData, floDataLen);
+		cbtx_size += floDataLen;
 		coinbase_append = true;
 	}
 	if (coinbase_append) {

--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -446,7 +446,7 @@ static struct option const options[] = {
 	{ "diff-factor", 1, NULL, 'f' },
 	{ "diff", 1, NULL, 'f' }, // deprecated (alias)
 	{ "diff-multiplier", 1, NULL, 'm' },
-	{ "flodata", 1, NULL, 1070 },
+	{ "flodata", 1, NULL, 'l' },
 	{ "help", 0, NULL, 'h' },
 	{ "nfactor", 1, NULL, 'n' },
 	{ "no-gbt", 0, NULL, 1011 },
@@ -3289,7 +3289,7 @@ void parse_arg(int key, char *arg)
 		if (p) d *= 1e9;
 		opt_max_rate = d;
 		break;
-	case 1070: // flodata message
+	case 'l': // flodata message
 		free(opt_flodata);
 		opt_flodata = strdup(arg);
 		break;

--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -292,6 +292,9 @@ char *opt_api_allow = NULL;
 int opt_api_remote = 0;
 int opt_api_listen = 4048; /* 0 to disable */
 
+// FLO Blockchain
+char *opt_flodata = NULL;
+
 #ifdef HAVE_GETOPT_LONG
 #include <getopt.h>
 #else
@@ -365,6 +368,7 @@ Options:\n\
                           xevan        Xevan (BitSend)\n\
                           yescrypt     Yescrypt\n\
                           zr5          ZR5\n\
+  -l, --flodata=MESSAGE	message for flodata field\n\
   -o, --url=URL         URL of mining server\n\
   -O, --userpass=U:P    username:password pair for mining server\n\
   -u, --user=USERNAME   username for mining server\n\
@@ -422,7 +426,7 @@ static char const short_options[] =
 #ifdef HAVE_SYSLOG_H
 	"S"
 #endif
-	"a:b:Bc:CDf:hm:n:p:Px:qr:R:s:t:T:o:u:O:V";
+	"a:b:Bc:CDf:hm:n:p:Px:qr:R:s:t:T:o:u:O:Vl:";
 
 static struct option const options[] = {
 	{ "algo", 1, NULL, 'a' },
@@ -442,6 +446,7 @@ static struct option const options[] = {
 	{ "diff-factor", 1, NULL, 'f' },
 	{ "diff", 1, NULL, 'f' }, // deprecated (alias)
 	{ "diff-multiplier", 1, NULL, 'm' },
+	{ "flodata", 1, NULL, 1070 },
 	{ "help", 0, NULL, 'h' },
 	{ "nfactor", 1, NULL, 'n' },
 	{ "no-gbt", 0, NULL, 1011 },
@@ -875,7 +880,12 @@ static bool gbt_work_decode(const json_t *val, struct work *work)
 		}
 		cbvalue = (int64_t) (json_is_integer(tmp) ? json_integer_value(tmp) : json_number_value(tmp));
 		cbtx = (uchar*) malloc(256);
-		le32enc((uint32_t *)cbtx, 2); /* version */
+		/* version == 1 if no flodata message, 2 if flodata message set */
+		if (opt_flodata == NULL) {
+                    le32enc((uint32_t *)cbtx, 1);
+		} else {
+		    le32enc((uint32_t *)cbtx, 2);
+		}
 		cbtx[4] = 1; /* in-counter */
 		memset(cbtx+5, 0x00, 32); /* prev txout hash */
 		le32enc((uint32_t *)(cbtx+37), 0xffffffff); /* prev txout index */
@@ -901,11 +911,14 @@ static bool gbt_work_decode(const json_t *val, struct work *work)
 		cbtx_size += (int) pk_script_size;
 		le32enc((uint32_t *)(cbtx+cbtx_size), 0); /* lock time */
 		cbtx_size += 4;
-		const char* floData = "MLG cpuminer-multi";
-		char floDataLen = strlen(floData); // only works if floData is less than 252 chars
-		cbtx[cbtx_size++] = floDataLen;    // else the encoded varInt will be wrong
-		memcpy(cbtx+cbtx_size, floData, floDataLen);
-		cbtx_size += floDataLen;
+
+		if (opt_flodata != NULL) {
+		    char floDataLen = strlen(opt_flodata); // only works if floData is less than 252 chars
+		    cbtx[cbtx_size++] = floDataLen;    // else the encoded varInt will be wrong
+		    memcpy(cbtx+cbtx_size, opt_flodata, floDataLen);
+		    cbtx_size += floDataLen;
+		}
+
 		coinbase_append = true;
 	}
 	if (coinbase_append) {
@@ -3275,6 +3288,10 @@ void parse_arg(int key, char *arg)
 		p = strstr(arg, "G");
 		if (p) d *= 1e9;
 		opt_max_rate = d;
+		break;
+	case 1070: // flodata message
+		free(opt_flodata);
+		opt_flodata = strdup(arg);
 		break;
 	case 1024:
 		opt_randomize = true;


### PR DESCRIPTION
The options, `-l` and `--flodata`, add a message to the floData field in the coinbase transaction. This only works for FLO Blockchain.