### PR TITLE
Rainforest optimizations for small L1 caches

### DIFF
--- a/algo/rainforest.c
+++ b/algo/rainforest.c
@@ -534,16 +534,15 @@ static inline uint64_t rf_bswap64(uint64_t v) {
 // lookup _old_ in _rambox_, update it and perform a substitution if a matching
 // value is found.
 static inline uint32_t rf_rambox(uint64_t *rambox, uint64_t old) {
-  uint64_t *p;
+  uint64_t *p, k;
   int loops;
 
   for (loops=0; loops<RAMBOX_LOOPS; loops++) {
     old=rf_add64_crc32(old);
     p=&rambox[old&(RAMBOX_SIZE-1)];
-    old+=rf_rotr64(*p, (uint8_t) (old/RAMBOX_SIZE));
-    // 0x80 below gives a write ratio of 50%
-    if ((old>>56)<0x80)
-      *p = old;
+    k = *p;
+    old+=rf_rotr64(k, (uint8_t) (old/RAMBOX_SIZE));
+    *p = (int64_t)old < 0 ? k : old;
   }
   return (uint32_t)old;
 }

--- a/algo/rainforest.c
+++ b/algo/rainforest.c
@@ -253,11 +253,11 @@ typedef union {
 } hash256_t;
 
 typedef struct _ALIGN(128) rf_ctx {
-  uint64_t rambox[RAMBOX_SIZE];
-  hash256_t hash;
-  uint32_t crc;
   uint32_t word;  // LE pending message
   uint32_t len;   // total message length
+  uint32_t crc;
+  hash256_t hash _ALIGN(32);
+  uint64_t rambox[RAMBOX_SIZE] _ALIGN(64);
 } rf256_ctx_t;
 
 // these archs are fine with unaligned reads

--- a/algo/rainforest.c
+++ b/algo/rainforest.c
@@ -845,6 +845,8 @@ int scanhash_rf256(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *
 #ifndef RF_DISABLE_CTX_MEMCPY
 		memcpy(&ctx, &ctx_common, sizeof(ctx));
 		rf256_update(&ctx, endiandata+19, 4);
+		if (ctx.hash.w[7])
+			goto next;
 		rf256_final(hash, &ctx);
 #else
 		rf256_hash(hash, endiandata, 80);
@@ -856,6 +858,7 @@ int scanhash_rf256(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *
 			*hashes_done = pdata[19] - first_nonce;
 			return 1;
 		}
+	next:
 		nonce++;
 	} while (nonce < max_nonce && !(*restart));
 

--- a/algo/rainforest.c
+++ b/algo/rainforest.c
@@ -329,6 +329,7 @@ const uint8_t rf256_iv[32] = {
 };
 
 // crc32 lookup tables
+#if !defined(__ARM_FEATURE_CRC32)
 const uint32_t rf_crc32_table[256] = {
   /* 0x00 */ 0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
   /* 0x04 */ 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
@@ -395,6 +396,7 @@ const uint32_t rf_crc32_table[256] = {
   /* 0xf8 */ 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
   /* 0xfc */ 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
 };
+#endif
 
 // compute the crc32 of 32-bit message _msg_ from previous crc _crc_.
 // build with -mcpu=cortex-a53+crc to enable native CRC instruction on ARM

--- a/build-linux-arm.sh
+++ b/build-linux-arm.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Linux build, optimised for ARM devices
+
+if [ ! -e configure ]; then
+	echo "Creating configure..."
+	rm -rf autom4te.cache
+	rm -f Makefile.in aclocal.m4 autom4te.cache compat/Makefile.in
+	rm -f compile config.guess config.sub config.status configure
+	rm -f cpuminer-config.h.in depcomp install-sh missing
+	if ./autogen.sh; then
+		echo "  => done."
+	else
+		exit 1
+	fi
+fi
+
+if [ -e Makefile ]; then
+	echo "Cleaning previous build..."
+	make distclean
+	echo "  => done."
+fi
+
+echo "Configuring..."
+
+# --disable-assembly: some ASM code doesn't build on ARM
+# Note: we don't enable -flto, it doesn't bring anything here but slows down
+# the build a lot. If needed, just add -flto to the CFLAGS string.
+# normal build.
+./configure --with-crypto --with-curl --disable-assembly CC=gcc CXX=g++ CFLAGS="-Ofast -fuse-linker-plugin -ftree-loop-if-convert-stores -march=native" LDFLAGS="-march=native"
+
+# debug build
+#./configure --with-crypto --with-curl --disable-assembly CC=gcc CXX=g++ CFLAGS="-O0 -g3 -fuse-linker-plugin -ftree-loop-if-convert-stores -march=native" LDFLAGS="-g3 -march=native"
+
+[ $? = 0 ] || exit $?
+echo "  => done."
+
+if [ -z "$NPROC" ]; then
+	NPROC=$(nproc 2>/dev/null)
+	NPROC=${NPROC:-1}
+fi
+
+echo "Compiling on $NPROC processes..."
+
+make -j $NPROC
+
+if [ $? != 0 ]; then
+	echo "Compilation failed (make=$?)".
+	echo "Common causes: missing libjansson-dev libcurl4-openssl-dev libssl-dev"
+	echo "If you pulled updates into this directory, remove configure and try again."
+	exit 1
+fi
+echo "  => done."
+
+echo '$ ls -l cpuminer'
+ls -l cpuminer
+
+echo "Stripping..."
+
+strip -s cpuminer
+
+[ $? = 0 ] || exit $?
+echo "  => done."


### PR DESCRIPTION
Hello,

As mentioned here https://github.com/bschn2/rainforest/pull/4#issuecomment-471714367 while using cpuminer + rainforest algo to stress some small ARM boards, I figured it heavily depended on the L1 cache's performance which is poor on Cortex A53. I managed to replace the memcpy() with a small history buffer which avoids copying 16kB each time causing cache thrashing. This multiplied the performance by ~10 for NanoPi boards, about 4 for RaspberryPi and 6 on x86_64. RPi even reports better results than my PC before the patch, and NanoPi is now 25% faster than the PC. Microbitcoin has already adopted this update.

I also added a small build script for ARM boards which passes --disable-assembly an -march=native as it significantly helps first-time users. It's indeed not obvious that the build errors reported by the default one are caused by the x86 asm code that is not available there.
