### PR TITLE
readme: add zlib1g-dev dep on deb-based Linux systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ _OR_
 #### Note for Debian/Ubuntu users:
 
 ```
- apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++
+ apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev zlib1g-dev make g++
 ```
 
 #### Note for OS X users:


### PR DESCRIPTION
Compiling on linux systems needs the headers of zlib so add them to the instructions