### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ _OR_
 #### Note for Debian/Ubuntu users:
 
 ```
- apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++
+ apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev make g++ zlib1g-dev
 ```
 
 #### Note for OS X users:


### PR DESCRIPTION
Unter Ubuntu 18.04 server, I had the following error, when I finally called make 

/usr/bin/ld: cannot find -lz
collect2: error: ld returned 1 exit status
Makefile:941: recipe for target 'cpuminer' failed
make[2]: *** [cpuminer] Error 1
make[2]: Leaving directory '/home/user1/dev/github/tpruvot/cpuminer-multi'
Makefile:2766: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/user1/dev/github/tpruvot/cpuminer-multi'
Makefile:585: recipe for target 'all' failed
make: *** [all] Error 2

I was able to solve it by installing 
zlib1g-dev

Therefore the Readme.md might be updated then