### PR TITLE
Removed ifdef that causes armv7l build to fail

### DIFF
--- a/algo/rainforest.c
+++ b/algo/rainforest.c
@@ -332,7 +332,6 @@ const uint8_t rf256_iv[32] = {
 };
 
 // crc32 lookup tables
-#if !defined(__ARM_FEATURE_CRC32)
 const uint32_t rf_crc32_table[256] = {
   /* 0x00 */ 0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
   /* 0x04 */ 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,

--- a/algo/rainforest.c
+++ b/algo/rainforest.c
@@ -399,7 +399,6 @@ const uint32_t rf_crc32_table[256] = {
   /* 0xf8 */ 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
   /* 0xfc */ 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
 };
-#endif
 
 // compute the crc32 of 32-bit message _msg_ from previous crc _crc_.
 // build with -mcpu=cortex-a53+crc to enable native CRC instruction on ARM


### PR DESCRIPTION
Might not be the best solution, but it won't hurt much.
I made this fix because when I tried to build for armv7l (32bit) platform compiler threw an error saying that this part is missing.
After this one it builds just fine